### PR TITLE
fix: use absolute imports to fix forge coverage

### DIFF
--- a/src/Kernel.sol
+++ b/src/Kernel.sol
@@ -9,8 +9,8 @@ import "./abstract/Compatibility.sol";
 import "./abstract/KernelStorage.sol";
 import "./utils/KernelHelper.sol";
 
-import "src/common/Constants.sol";
-import "src/common/Enum.sol";
+import "./common/Constants.sol";
+import "./common/Enum.sol";
 
 /// @title Kernel
 /// @author taek<leekt216@gmail.com>

--- a/src/abstract/KernelStorage.sol
+++ b/src/abstract/KernelStorage.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 
 // Importing necessary interfaces
 import "account-abstraction/interfaces/IEntryPoint.sol";
-import "src/interfaces/IValidator.sol";
-import "src/common/Constants.sol";
-import "src/common/Structs.sol";
+import "../interfaces/IValidator.sol";
+import "../common/Constants.sol";
+import "../common/Structs.sol";
 
 /// @title Kernel Storage Contract
 /// @author taek<leekt216@gmail.com>

--- a/src/common/Structs.sol
+++ b/src/common/Structs.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IValidator.sol";
-import "src/common/Enum.sol";
-import "src/common/Types.sol";
+import "../interfaces/IValidator.sol";
+import "./Enum.sol";
+import "./Types.sol";
 
 // Defining a struct for execution details
 struct ExecutionDetail {

--- a/src/common/Types.sol
+++ b/src/common/Types.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.9;
 
-import "src/common/Constants.sol";
+import "./Constants.sol";
 
 type ValidAfter is uint48;
 

--- a/src/executor/KillSwitchAction.sol
+++ b/src/executor/KillSwitchAction.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.8.18;
 
-import "src/interfaces/IValidator.sol";
-import "src/validator/KillSwitchValidator.sol";
-import "src/abstract/KernelStorage.sol";
+import "../interfaces/IValidator.sol";
+import "../validator/KillSwitchValidator.sol";
+import "../abstract/KernelStorage.sol";
 
 contract KillSwitchAction {
     KillSwitchValidator public immutable killSwitchValidator;

--- a/src/factory/KernelFactory.sol
+++ b/src/factory/KernelFactory.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.0;
 import "./AdminLessERC1967Factory.sol";
 
 import "openzeppelin-contracts/contracts/utils/Create2.sol";
-import "src/Kernel.sol";
-import "src/validator/ECDSAValidator.sol";
+import "../Kernel.sol";
+import "../validator/ECDSAValidator.sol";
 import "solady/auth/Ownable.sol";
 
 contract KernelFactory is AdminLessERC1967Factory, Ownable {

--- a/src/interfaces/IValidator.sol
+++ b/src/interfaces/IValidator.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {UserOperation} from "account-abstraction/interfaces/UserOperation.sol";
-import "src/common/Types.sol";
+import "../common/Types.sol";
 
 interface IKernelValidator {
     function enable(bytes calldata _data) external payable;

--- a/src/test/TestKernel.sol
+++ b/src/test/TestKernel.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.0;
 
-import "src/Kernel.sol";
+import "../Kernel.sol";
 
 contract TestKernel is Kernel {
     constructor(IEntryPoint _entryPoint) Kernel(_entryPoint) {}

--- a/src/test/TestValidator.sol
+++ b/src/test/TestValidator.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "src/interfaces/IValidator.sol";
-import "src/common/Types.sol";
+import "../interfaces/IValidator.sol";
+import "../common/Types.sol";
 
 contract TestValidator is IKernelValidator {
     event TestValidateUserOp(bytes32 indexed opHash);

--- a/src/utils/KernelHelper.sol
+++ b/src/utils/KernelHelper.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {SIG_VALIDATION_FAILED_UINT} from "src/common/Constants.sol";
-import {ValidationData} from "src/common/Types.sol";
+import {SIG_VALIDATION_FAILED_UINT} from "../common/Constants.sol";
+import {ValidationData} from "../common/Types.sol";
 
 function _intersectValidationData(ValidationData a, ValidationData b) pure returns (ValidationData validationData) {
     assembly {

--- a/src/validator/ECDSAValidator.sol
+++ b/src/validator/ECDSAValidator.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 import "solady/utils/ECDSA.sol";
-import "src/utils/KernelHelper.sol";
-import "src/interfaces/IValidator.sol";
-import "src/common/Types.sol";
+import "../utils/KernelHelper.sol";
+import "../interfaces/IValidator.sol";
+import "../common/Types.sol";
 
 struct ECDSAValidatorStorage {
     address owner;

--- a/src/validator/ERC165SessionKeyValidator.sol
+++ b/src/validator/ERC165SessionKeyValidator.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 
 import "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
 import "solady/utils/ECDSA.sol";
-import "src/utils/KernelHelper.sol";
-import "src/interfaces/IValidator.sol";
-import "src/common/Types.sol";
+import "../utils/KernelHelper.sol";
+import "../interfaces/IValidator.sol";
+import "../common/Types.sol";
 
 // idea, we can make this merkle root
 struct ERC165SessionKeyStorage {

--- a/src/validator/KillSwitchValidator.sol
+++ b/src/validator/KillSwitchValidator.sol
@@ -3,12 +3,12 @@
 pragma solidity ^0.8.0;
 
 import "solady/utils/ECDSA.sol";
-import "src/utils/KernelHelper.sol";
-import "src/Kernel.sol";
-import {WalletKernelStorage, ExecutionDetail} from "src/abstract/KernelStorage.sol";
-import "src/interfaces/IValidator.sol";
-import "src/common/Types.sol";
-import {KillSwitchAction} from "src/executor/KillSwitchAction.sol";
+import "../utils/KernelHelper.sol";
+import "../Kernel.sol";
+import {WalletKernelStorage, ExecutionDetail} from "../abstract/KernelStorage.sol";
+import "../interfaces/IValidator.sol";
+import "../common/Types.sol";
+import {KillSwitchAction} from "../executor/KillSwitchAction.sol";
 
 struct KillSwitchValidatorStorage {
     address guardian;

--- a/src/validator/MultiECDSAValidator.sol
+++ b/src/validator/MultiECDSAValidator.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.0;
 
 import "solady/utils/ECDSA.sol";
-import "src/utils/KernelHelper.sol";
-import "src/interfaces/IAddressBook.sol";
-import "src/interfaces/IValidator.sol";
-import "src/common/Types.sol";
+import "../utils/KernelHelper.sol";
+import "../interfaces/IAddressBook.sol";
+import "../interfaces/IValidator.sol";
+import "../common/Types.sol";
 
 contract MultiECDSAValidator is IKernelValidator {
     event OwnerAdded(address indexed kernel, address indexed owner);

--- a/src/validator/SessionKeyOwnedValidator.sol
+++ b/src/validator/SessionKeyOwnedValidator.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.0;
 
 import "solady/utils/ECDSA.sol";
 import "solady/utils/EIP712.sol";
-import "src/utils/KernelHelper.sol";
-import "src/interfaces/IValidator.sol";
-import "src/common/Types.sol";
+import "../utils/KernelHelper.sol";
+import "../interfaces/IValidator.sol";
+import "../common/Types.sol";
 
 struct SessionKeyStorage {
     ValidUntil validUntil;

--- a/src/validator/SessionKeyValidator.sol
+++ b/src/validator/SessionKeyValidator.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.8.0;
 
 import "solady/utils/ECDSA.sol";
-import "src/interfaces/IValidator.sol";
+import "../interfaces/IValidator.sol";
 import "solady/utils/MerkleProofLib.sol";
-import "src/common/Constants.sol";
-import "src/common/Enum.sol";
-import "src/common/Structs.sol";
-import "src/common/Types.sol";
+import "../common/Constants.sol";
+import "../common/Enum.sol";
+import "../common/Structs.sol";
+import "../common/Types.sol";
 
 contract ExecuteSessionKeyValidator is IKernelValidator {
     mapping(address sessionKey => mapping(address kernel => SessionData)) public sessionData;


### PR DESCRIPTION
When Kernel is used as a dependency on a project, that project's forge coverage might fail to run because of a dependency resolution issue when relative import paths are used.
This should fix the same issue other projects may have or might run into.