### PR TITLE
chore: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name":"kernel",
+  "version":"3.0.0",
   "license": "MIT",
   "scripts": {
     "compile": "hardhat compile"


### PR DESCRIPTION
- Added name and version field. 

In absence of these fields, hardhat will through error if Kernel is used as local npm package.