### PR TITLE
feat: enhance ECDSAExecutor with 2D-nonce system and security improvements

### DIFF
--- a/src/executor/ECDSAExecutor.sol
+++ b/src/executor/ECDSAExecutor.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {ECDSA} from "solady/utils/ECDSA.sol";
+import {IExecutor} from "../interfaces/IERC7579Modules.sol";
+import {IERC7579Account, ExecMode} from "../interfaces/IERC7579Account.sol";
+import {MODULE_TYPE_EXECUTOR} from "../types/Constants.sol";
+
+struct ECDSAExecutorStorage {
+    address owner;
+    mapping(uint192 => uint256) nonceSequenceNumber;
+}
+
+contract ECDSAExecutor is IExecutor {
+    error InvalidNonce(address account, uint256 expected, uint256 actual);
+    error SignatureExpired(address account, uint256 expiration);
+    error InvalidSignature();
+    error InvalidOwner();
+    
+    event OwnerRegistered(address indexed kernel, address indexed owner);
+    event OwnerUnregistered(address indexed kernel, address indexed owner);
+    event ExecutionRequested(address indexed kernel, bytes32 indexed executionHash);
+
+    mapping(address => ECDSAExecutorStorage) internal ecdsaExecutorStorage;
+
+    function onInstall(bytes calldata _data) external payable override {
+        address owner = address(bytes20(_data[0:20]));
+        if (owner == address(0)) revert InvalidOwner();
+        ecdsaExecutorStorage[msg.sender].owner = owner;
+        emit OwnerRegistered(msg.sender, owner);
+    }
+
+    function onUninstall(bytes calldata) external payable override {
+        if (!_isInitialized(msg.sender)) revert NotInitialized(msg.sender);
+        address owner = ecdsaExecutorStorage[msg.sender].owner;
+        delete ecdsaExecutorStorage[msg.sender];
+        emit OwnerUnregistered(msg.sender, owner);
+    }
+
+    function isModuleType(uint256 typeID) external pure override returns (bool) {
+        return typeID == MODULE_TYPE_EXECUTOR;
+    }
+
+    function isInitialized(address smartAccount) external view override returns (bool) {
+        return _isInitialized(smartAccount);
+    }
+
+    function _isInitialized(address smartAccount) internal view returns (bool) {
+        return ecdsaExecutorStorage[smartAccount].owner != address(0);
+    }
+
+    function getOwner(address account) external view returns (address) {
+        return ecdsaExecutorStorage[account].owner;
+    }
+
+    function getNonce(address account, uint192 key) external view returns (uint256) {
+        return ecdsaExecutorStorage[account].nonceSequenceNumber[key];
+    }
+
+    function _packNonce(uint192 key, uint256 sequence) internal pure returns (uint256) {
+        return (uint256(key) << 64) | sequence;
+    }
+
+    function _unpackNonce(uint256 nonce) internal pure returns (uint192 key, uint256 sequence) {
+        key = uint192(nonce >> 64);
+        sequence = uint256(uint64(nonce));
+    }
+
+    function incrementNonce(uint192 key) external {
+        // Only the account itself can increment its nonce
+        if (!_isInitialized(msg.sender)) revert NotInitialized(msg.sender);
+        ecdsaExecutorStorage[msg.sender].nonceSequenceNumber[key]++;
+    }
+
+    function execute(
+        address account,
+        ExecMode mode,
+        bytes calldata executionCalldata,
+        uint256 nonce,
+        uint256 expiration,
+        bytes calldata signature
+    ) external payable returns (bytes[] memory returnData) {
+        if (!_isInitialized(account)) revert NotInitialized(account);
+        
+        // Validate expiration
+        if (block.timestamp > expiration) {
+            revert SignatureExpired(account, expiration);
+        }
+        
+        // Validate and update nonce
+        _validateAndUpdateNonce(account, nonce);
+        
+        // Verify signature and execute
+        bytes32 executionHash = keccak256(
+            abi.encode(account, mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        
+        emit ExecutionRequested(account, executionHash);
+        
+        address owner = ecdsaExecutorStorage[account].owner;
+        if (owner == ECDSA.recover(executionHash, signature)) {
+            return IERC7579Account(account).executeFromExecutor(mode, executionCalldata);
+        }
+        
+        bytes32 ethHash = ECDSA.toEthSignedMessageHash(executionHash);
+        if (owner != ECDSA.recover(ethHash, signature)) {
+            revert InvalidSignature();
+        }
+        
+        return IERC7579Account(account).executeFromExecutor(mode, executionCalldata);
+    }
+    
+    function _validateAndUpdateNonce(address account, uint256 nonce) internal {
+        (uint192 key, uint256 sequence) = _unpackNonce(nonce);
+        uint256 expectedSequence = ecdsaExecutorStorage[account].nonceSequenceNumber[key];
+        if (sequence != expectedSequence) {
+            revert InvalidNonce(account, _packNonce(key, expectedSequence), nonce);
+        }
+        ecdsaExecutorStorage[account].nonceSequenceNumber[key] = sequence + 1;
+    }
+}

--- a/test/ECDSAExecutor.t.sol
+++ b/test/ECDSAExecutor.t.sol
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+import {ECDSAExecutor} from "../src/executor/ECDSAExecutor.sol";
+import {IModule} from "../src/interfaces/IERC7579Modules.sol";
+import {IERC7579Account, ExecMode} from "../src/interfaces/IERC7579Account.sol";
+import {ExecLib} from "../src/utils/ExecLib.sol";
+import {MODULE_TYPE_EXECUTOR, CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, CALLTYPE_BATCH, CallType} from "../src/types/Constants.sol";
+import {ExecModePayload} from "../src/types/Types.sol";
+import {Execution} from "../src/types/Structs.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
+import {PackedUserOperation} from "../src/interfaces/PackedUserOperation.sol";
+
+contract MockTarget {
+    uint256 public value;
+    
+    function setValue(uint256 _value) external {
+        value = _value;
+    }
+    
+    function getValue() external view returns (uint256) {
+        return value;
+    }
+}
+
+// Mock account for testing
+contract MockAccount is IERC7579Account {
+    mapping(address => bool) public isExecutor;
+    
+    function installModule(uint256, address module, bytes calldata data) external payable {
+        isExecutor[module] = true;
+        IModule(module).onInstall(data);
+    }
+    
+    function uninstallModule(uint256, address module, bytes calldata data) external payable {
+        isExecutor[module] = false;
+        IModule(module).onUninstall(data);
+    }
+    
+    function executeFromExecutor(ExecMode mode, bytes calldata executionCalldata) external payable returns (bytes[] memory returnData) {
+        require(isExecutor[msg.sender], "Not authorized executor");
+        
+        // For testing purposes, just execute whatever calls are encoded
+        // This is a simplified mock that doesn't need to handle all edge cases
+        
+        (CallType callType,,, ) = ExecLib.decode(mode);
+        
+        if (callType == CALLTYPE_SINGLE) {
+            (address target, uint256 value, bytes memory data) = ExecLib.decodeSingle(executionCalldata);
+            (bool success, bytes memory result) = target.call{value: value}(data);
+            require(success, "Execution failed");
+            returnData = new bytes[](1);
+            returnData[0] = result;
+        } else {
+            // For batch test - ExecLib.encodeBatch just does abi.encode(executions)
+            Execution[] memory executions = abi.decode(executionCalldata, (Execution[]));
+            returnData = new bytes[](executions.length);
+            
+            for (uint256 i = 0; i < executions.length; i++) {
+                (bool success, bytes memory result) = executions[i].target.call{value: executions[i].value}(executions[i].callData);
+                require(success, "Batch execution failed");
+                returnData[i] = result;
+            }
+        }
+    }
+    
+    function execute(ExecMode, bytes calldata) external payable {}
+    function executeUserOp(PackedUserOperation calldata, bytes32) external payable {}
+    function validateUserOp(PackedUserOperation calldata, bytes32, uint256) external payable returns (uint256) {}
+    function isValidSignature(bytes32, bytes calldata) external view returns (bytes4) {}
+    function supportsExecutionMode(ExecMode) external view returns (bool) { return true; }
+    function supportsModule(uint256) external view returns (bool) { return true; }
+    function isModuleInstalled(uint256, address, bytes calldata) external view returns (bool) {}
+    function accountId() external view returns (string memory) {}
+}
+
+contract ECDSAExecutorTest is Test {
+    using ECDSA for bytes32;
+    using ExecLib for bytes;
+    
+    // Event declarations for testing
+    event OwnerRegistered(address indexed kernel, address indexed owner);
+    event OwnerUnregistered(address indexed kernel, address indexed owner);
+
+    ECDSAExecutor executor;
+    MockAccount account;
+    MockTarget target;
+
+    address owner;
+    uint256 ownerKey;
+
+    function setUp() public {
+        // Deploy contracts
+        executor = new ECDSAExecutor();
+        target = new MockTarget();
+        account = new MockAccount();
+        
+        (owner, ownerKey) = makeAddrAndKey("owner");
+        
+        // Install the ECDSA executor module
+        bytes memory installData = abi.encodePacked(owner);
+        account.installModule(MODULE_TYPE_EXECUTOR, address(executor), installData);
+    }
+
+    function testInstallExecutor() public {
+        // First uninstall the executor to test fresh install
+        vm.prank(address(account));
+        account.uninstallModule(MODULE_TYPE_EXECUTOR, address(executor), bytes(""));
+        
+        assertFalse(executor.isInitialized(address(account)));
+        
+        // Now test install with event
+        bytes memory installData = abi.encodePacked(owner);
+        
+        // Expect the OwnerRegistered event
+        vm.expectEmit(true, true, false, true, address(executor));
+        emit OwnerRegistered(address(account), owner);
+        
+        account.installModule(MODULE_TYPE_EXECUTOR, address(executor), installData);
+        
+        assertTrue(executor.isInitialized(address(account)));
+        assertEq(executor.getOwner(address(account)), owner);
+    }
+
+    function testExecuteWithValidSignature() public {
+        uint256 newValue = 42;
+        bytes memory callData = abi.encodeWithSelector(MockTarget.setValue.selector, newValue);
+        
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeSingle(address(target), 0, callData);
+        
+        uint256 nonce = 0; // Using key 0, sequence 0
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(account), mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, executionHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        executor.execute(address(account), mode, executionCalldata, nonce, expiration, signature);
+        
+        assertEq(target.getValue(), newValue);
+    }
+
+    function testExecuteWithEIP191Signature() public {
+        uint256 newValue = 99;
+        bytes memory callData = abi.encodeWithSelector(MockTarget.setValue.selector, newValue);
+        
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeSingle(address(target), 0, callData);
+        
+        uint256 nonce = 0; // Using key 0, sequence 0
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(account), mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        bytes32 ethHash = ECDSA.toEthSignedMessageHash(executionHash);
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, ethHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        executor.execute(address(account), mode, executionCalldata, nonce, expiration, signature);
+        
+        assertEq(target.getValue(), newValue);
+    }
+
+    function testExecuteWithInvalidSignature() public {
+        (, uint256 wrongKey) = makeAddrAndKey("wrong");
+        uint256 newValue = 50;
+        bytes memory callData = abi.encodeWithSelector(MockTarget.setValue.selector, newValue);
+        
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeSingle(address(target), 0, callData);
+        
+        uint256 nonce = 0; // Using key 0, sequence 0
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(account), mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongKey, executionHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        vm.expectRevert(abi.encodeWithSelector(ECDSAExecutor.InvalidSignature.selector));
+        executor.execute(address(account), mode, executionCalldata, nonce, expiration, signature);
+    }
+
+    function testUninstallExecutor() public {
+        assertTrue(executor.isInitialized(address(account)));
+        
+        // Expect the OwnerUnregistered event
+        vm.expectEmit(true, true, false, true, address(executor));
+        emit OwnerUnregistered(address(account), owner);
+        
+        vm.prank(address(account));
+        account.uninstallModule(MODULE_TYPE_EXECUTOR, address(executor), bytes(""));
+        
+        assertFalse(executor.isInitialized(address(account)));
+    }
+
+    function testExecuteBatch() public {
+        MockTarget target2 = new MockTarget();
+        
+        uint256 value1 = 100;
+        uint256 value2 = 200;
+        
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution({
+            target: address(target),
+            value: 0,
+            callData: abi.encodeWithSelector(MockTarget.setValue.selector, value1)
+        });
+        executions[1] = Execution({
+            target: address(target2),
+            value: 0,
+            callData: abi.encodeWithSelector(MockTarget.setValue.selector, value2)
+        });
+        
+        ExecMode mode = ExecLib.encode(CALLTYPE_BATCH, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeBatch(executions);
+        
+        uint256 nonce = 0; // Using key 0, sequence 0
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(account), mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, executionHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        executor.execute(address(account), mode, executionCalldata, nonce, expiration, signature);
+        
+        assertEq(target.getValue(), value1);
+        assertEq(target2.getValue(), value2);
+    }
+
+    function testInvalidNonce() public {
+        uint256 newValue = 42;
+        bytes memory callData = abi.encodeWithSelector(MockTarget.setValue.selector, newValue);
+        
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeSingle(address(target), 0, callData);
+        
+        uint256 wrongNonce = 1; // Should be 0 for first transaction
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(account), mode, executionCalldata, wrongNonce, expiration, block.chainid)
+        );
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, executionHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        vm.expectRevert(abi.encodeWithSelector(ECDSAExecutor.InvalidNonce.selector, address(account), 0, wrongNonce));
+        executor.execute(address(account), mode, executionCalldata, wrongNonce, expiration, signature);
+    }
+
+    function testParallelNonces() public {
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        // Execute with key 0
+        uint256 nonce1 = 0; // key 0, sequence 0
+        bytes memory executionCalldata1 = ExecLib.encodeSingle(
+            address(target), 
+            0, 
+            abi.encodeWithSelector(MockTarget.setValue.selector, 100)
+        );
+        
+        bytes32 executionHash1 = keccak256(
+            abi.encode(address(account), mode, executionCalldata1, nonce1, expiration, block.chainid)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, executionHash1);
+        
+        executor.execute(address(account), mode, executionCalldata1, nonce1, expiration, abi.encodePacked(r, s, v));
+        assertEq(target.getValue(), 100);
+        
+        // Execute with key 1 (can execute in parallel)
+        uint256 nonce2 = uint256(1) << 64; // key 1, sequence 0
+        bytes memory executionCalldata2 = ExecLib.encodeSingle(
+            address(target), 
+            0, 
+            abi.encodeWithSelector(MockTarget.setValue.selector, 200)
+        );
+        
+        bytes32 executionHash2 = keccak256(
+            abi.encode(address(account), mode, executionCalldata2, nonce2, expiration, block.chainid)
+        );
+        (v, r, s) = vm.sign(ownerKey, executionHash2);
+        
+        executor.execute(address(account), mode, executionCalldata2, nonce2, expiration, abi.encodePacked(r, s, v));
+        assertEq(target.getValue(), 200);
+        
+        // Check nonces
+        assertEq(executor.getNonce(address(account), 0), 1);
+        assertEq(executor.getNonce(address(account), 1), 1);
+    }
+
+    function testIncrementNonce() public {
+        uint192 key = 5;
+        
+        // Check initial nonce
+        assertEq(executor.getNonce(address(account), key), 0);
+        
+        // Increment nonce
+        vm.prank(address(account));
+        executor.incrementNonce(key);
+        
+        // Check incremented nonce
+        assertEq(executor.getNonce(address(account), key), 1);
+        
+        // Increment again
+        vm.prank(address(account));
+        executor.incrementNonce(key);
+        
+        // Check nonce
+        assertEq(executor.getNonce(address(account), key), 2);
+    }
+
+    function testReplayProtection() public {
+        uint256 newValue = 42;
+        bytes memory callData = abi.encodeWithSelector(MockTarget.setValue.selector, newValue);
+        
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeSingle(address(target), 0, callData);
+        
+        uint256 nonce = 0;
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(account), mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, executionHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        // First execution should succeed
+        executor.execute(address(account), mode, executionCalldata, nonce, expiration, signature);
+        assertEq(target.getValue(), newValue);
+        
+        // Replay should fail
+        vm.expectRevert(abi.encodeWithSelector(ECDSAExecutor.InvalidNonce.selector, address(account), 1, nonce));
+        executor.execute(address(account), mode, executionCalldata, nonce, expiration, signature);
+    }
+
+    function testExpiredSignature() public {
+        uint256 newValue = 42;
+        bytes memory callData = abi.encodeWithSelector(MockTarget.setValue.selector, newValue);
+        
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeSingle(address(target), 0, callData);
+        
+        uint256 nonce = 0;
+        uint256 expiration = block.timestamp - 1; // Already expired
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(account), mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, executionHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        // Should revert with SignatureExpired error
+        vm.expectRevert(abi.encodeWithSelector(ECDSAExecutor.SignatureExpired.selector, address(account), expiration));
+        executor.execute(address(account), mode, executionCalldata, nonce, expiration, signature);
+    }
+
+    function testInvalidOwnerAddress() public {
+        // Create a new account for this test
+        MockAccount newAccount = new MockAccount();
+        
+        // Try to install with zero address as owner
+        bytes memory invalidInstallData = abi.encodePacked(address(0));
+        
+        vm.expectRevert(abi.encodeWithSelector(ECDSAExecutor.InvalidOwner.selector));
+        newAccount.installModule(MODULE_TYPE_EXECUTOR, address(executor), invalidInstallData);
+    }
+
+    function testIsModuleType() public {
+        // Test that MODULE_TYPE_EXECUTOR returns true
+        assertTrue(executor.isModuleType(MODULE_TYPE_EXECUTOR));
+        
+        // Test that other module types return false
+        assertFalse(executor.isModuleType(1)); // MODULE_TYPE_VALIDATOR
+        assertFalse(executor.isModuleType(3)); // MODULE_TYPE_HOOK
+        assertFalse(executor.isModuleType(4)); // MODULE_TYPE_POLICY
+        assertFalse(executor.isModuleType(5)); // MODULE_TYPE_SIGNER
+        assertFalse(executor.isModuleType(6)); // MODULE_TYPE_ACTION
+        assertFalse(executor.isModuleType(999)); // Random type
+    }
+
+    function testUninstallNotInitialized() public {
+        // Create a new account that hasn't installed the executor
+        MockAccount newAccount = new MockAccount();
+        
+        // Try to uninstall without having installed first
+        vm.expectRevert(abi.encodeWithSelector(IModule.NotInitialized.selector, address(newAccount)));
+        vm.prank(address(newAccount));
+        executor.onUninstall(bytes(""));
+    }
+
+    function testIncrementNonceNotInitialized() public {
+        // Create a new account that hasn't installed the executor
+        MockAccount newAccount = new MockAccount();
+        
+        // Try to increment nonce without being initialized
+        vm.expectRevert(abi.encodeWithSelector(IModule.NotInitialized.selector, address(newAccount)));
+        vm.prank(address(newAccount));
+        executor.incrementNonce(0);
+    }
+
+    function testExecuteNotInitialized() public {
+        // Create a new account that hasn't installed the executor
+        MockAccount newAccount = new MockAccount();
+        
+        // Prepare execution data
+        bytes memory callData = abi.encodeWithSelector(MockTarget.setValue.selector, 42);
+        ExecMode mode = ExecLib.encode(CALLTYPE_SINGLE, EXECTYPE_DEFAULT, EXEC_MODE_DEFAULT, ExecModePayload.wrap(0));
+        bytes memory executionCalldata = ExecLib.encodeSingle(address(target), 0, callData);
+        
+        uint256 nonce = 0;
+        uint256 expiration = block.timestamp + 1 hours;
+        
+        bytes32 executionHash = keccak256(
+            abi.encode(address(newAccount), mode, executionCalldata, nonce, expiration, block.chainid)
+        );
+        
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerKey, executionHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        
+        // Should revert because account is not initialized
+        vm.expectRevert(abi.encodeWithSelector(IModule.NotInitialized.selector, address(newAccount)));
+        executor.execute(address(newAccount), mode, executionCalldata, nonce, expiration, signature);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement 2D-nonce system compatible with EntryPoint v0.7 for parallel transaction execution
- Add comprehensive security improvements and achieve 100% test coverage
- Add signature expiration time validation for time-bounded operations

## Changes
### Core Features
- **2D-nonce system**: Implemented key-based nonces allowing parallel execution of transactions with different keys
- **Signature expiration**: Added expiration time parameter to prevent stale signature replay
- **Event emission**: Added `OwnerUnregistered` event on module uninstall for better transparency

### Security Improvements
- Added zero address validation in `onInstall` to prevent invalid owner registration
- Added proper error types (`InvalidSignature`, `InvalidOwner`) for clearer error handling
- Restricted `incrementNonce` to initialized accounts only (was previously external without access control)
- Proper nonce validation and increment logic to prevent replay attacks

### Testing
- Achieved 100% test coverage (lines, statements, branches, and functions)
- Added comprehensive edge case tests including:
  - Module type validation
  - Uninstall on non-initialized accounts
  - Nonce increment on non-initialized accounts
  - Execute on non-initialized accounts
  - Parallel nonce execution
  - Signature expiration validation
  - Invalid owner address handling

## Test Results
```
╭-------------------------------------------+-----------------+-----------------+----------------+-----------------╮
| File                                      | % Lines         | % Statements    | % Branches     | % Funcs         |
+==================================================================================================================+
| src/executor/ECDSAExecutor.sol            | 100.00% (48/48) | 100.00% (51/51) | 100.00% (8/8)  | 100.00% (12/12) |
╰-------------------------------------------+-----------------+-----------------+----------------+-----------------╯
```

All 16 tests passing:
- testExecuteBatch
- testExecuteNotInitialized
- testExecuteWithEIP191Signature
- testExecuteWithInvalidSignature
- testExecuteWithValidSignature
- testExpiredSignature
- testIncrementNonce
- testIncrementNonceNotInitialized
- testInstallExecutor
- testInvalidNonce
- testInvalidOwnerAddress
- testIsModuleType
- testParallelNonces
- testReplayProtection
- testUninstallExecutor
- testUninstallNotInitialized

🤖 Generated with [Claude Code](https://claude.ai/code)