### PR TITLE
feat: make KernelTestBase setUp virtual to allow inheritance

### DIFF
--- a/test/base/KernelTestBase.sol
+++ b/test/base/KernelTestBase.sol
@@ -303,7 +303,7 @@ abstract contract KernelTestBase is TestPlus, Test {
         }
     }
 
-    function setUp() public {
+    function setUp() public virtual {
         enabledPermission = PermissionId.wrap(bytes4(0xdeadbeef));
         entrypoint = IEntryPoint(EntryPointLib.deploy());
         Kernel impl = new Kernel(entrypoint);


### PR DESCRIPTION
Building kernel modules is easier if implementors can inherit the test suite that has already been developed